### PR TITLE
Remove authentication from url shortener function

### DIFF
--- a/src/api/function/UrlArchive.cs
+++ b/src/api/function/UrlArchive.cs
@@ -50,7 +50,7 @@ namespace Cloud5mins.Function
 
         public UrlArchive(ILoggerFactory loggerFactory, AdminApiSettings settings)
         {
-            _logger = loggerFactory.CreateLogger<UrlList>();
+            _logger = loggerFactory.CreateLogger<UrlArchive>();
             _adminApiSettings = settings;
         }
 
@@ -75,16 +75,16 @@ namespace Cloud5mins.Function
                 // Validation of the inputs
                 if (req == null)
                 {
-                    return req.CreateResponse(  HttpStatusCode.NotFound);
+                    return req.CreateResponse(HttpStatusCode.NotFound);
                 }
 
                 using (var reader = new StreamReader(req.Body))
                 {
                     var body = reader.ReadToEnd();
-                    input = JsonSerializer.Deserialize<ShortUrlEntity>(body, new JsonSerializerOptions {PropertyNameCaseInsensitive = true});
+                    input = JsonSerializer.Deserialize<ShortUrlEntity>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
                     if (input == null)
                     {
-                        return req.CreateResponse(  HttpStatusCode.NotFound);
+                        return req.CreateResponse(HttpStatusCode.NotFound);
                     }
                 }
 
@@ -96,13 +96,13 @@ namespace Cloud5mins.Function
             {
                 _logger.LogError(ex, "An unexpected error was encountered.");
                 var badRequest = req.CreateResponse(HttpStatusCode.BadRequest);
-                await badRequest.WriteAsJsonAsync(new  { Message =  ex.Message} );    
-                return badRequest;   
+                await badRequest.WriteAsJsonAsync(new { Message = ex.Message });
+                return badRequest;
             }
 
             var response = req.CreateResponse(HttpStatusCode.OK);
-            await response.WriteAsJsonAsync(result);   
-            return response;   
+            await response.WriteAsJsonAsync(result);
+            return response;
         }
     }
 }

--- a/src/api/function/UrlShortener.cs
+++ b/src/api/function/UrlShortener.cs
@@ -43,7 +43,7 @@ namespace Cloud5mins.Function
 
         public UrlShortener(ILoggerFactory loggerFactory, AdminApiSettings settings)
         {
-            _logger = loggerFactory.CreateLogger<UrlList>();
+            _logger = loggerFactory.CreateLogger<UrlShortener>();
             _adminApiSettings = settings;
         }
 
@@ -60,12 +60,6 @@ namespace Cloud5mins.Function
 
             try
             {
-                var invalidCode = ClaimsUtility.CatchUnauthorize(req, _logger);
-                if (invalidCode != HttpStatusCode.Continue)
-                {
-                    return req.CreateResponse(invalidCode);
-                }
-
                 // Validation of the inputs
                 if (req == null)
                 {

--- a/src/api/function/UrlUpdate.cs
+++ b/src/api/function/UrlUpdate.cs
@@ -56,7 +56,7 @@ namespace Cloud5mins.Function
 
         public UrlUpdate(ILoggerFactory loggerFactory, AdminApiSettings settings)
         {
-            _logger = loggerFactory.CreateLogger<UrlList>();
+            _logger = loggerFactory.CreateLogger<UrlUpdate>();
             _adminApiSettings = settings;
         }
 
@@ -83,7 +83,7 @@ namespace Cloud5mins.Function
                 // Validation of the inputs
                 if (req == null)
                 {
-                    return req.CreateResponse(  HttpStatusCode.NotFound);
+                    return req.CreateResponse(HttpStatusCode.NotFound);
                 }
 
                 using (var reader = new StreamReader(req.Body))
@@ -92,7 +92,7 @@ namespace Cloud5mins.Function
                     input = JsonSerializer.Deserialize<ShortUrlEntity>(strBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
                     if (input == null)
                     {
-                        return req.CreateResponse(  HttpStatusCode.NotFound);
+                        return req.CreateResponse(HttpStatusCode.NotFound);
                     }
                 }
 
@@ -100,16 +100,16 @@ namespace Cloud5mins.Function
                 if (string.IsNullOrWhiteSpace(input.Url))
                 {
                     var badRequest = req.CreateResponse(HttpStatusCode.BadRequest);
-                    await badRequest.WriteAsJsonAsync(new  { Message = "The url parameter can not be empty."} );    
-                    return badRequest;     
+                    await badRequest.WriteAsJsonAsync(new { Message = "The url parameter can not be empty." });
+                    return badRequest;
                 }
 
                 // Validates if input.url is a valid aboslute url, aka is a complete refrence to the resource, ex: http(s)://google.com
                 if (!Uri.IsWellFormedUriString(input.Url, UriKind.Absolute))
                 {
                     var badRequest = req.CreateResponse(HttpStatusCode.BadRequest);
-                    await badRequest.WriteAsJsonAsync(new  { Message = $"{input.Url} is not a valid absolute Url. The Url parameter must start with 'http://' or 'http://'."} );    
-                    return badRequest;   
+                    await badRequest.WriteAsJsonAsync(new { Message = $"{input.Url} is not a valid absolute Url. The Url parameter must start with 'http://' or 'http://'." });
+                    return badRequest;
                 }
 
                 StorageTableHelper stgHelper = new StorageTableHelper(_adminApiSettings.UlsDataStorage);
@@ -124,13 +124,13 @@ namespace Cloud5mins.Function
                 _logger.LogError(ex, "An unexpected error was encountered.");
 
                 var badRequest = req.CreateResponse(HttpStatusCode.BadRequest);
-                await badRequest.WriteAsJsonAsync(new  { Message =  ex.Message} );    
-                return badRequest;   
+                await badRequest.WriteAsJsonAsync(new { Message = ex.Message });
+                return badRequest;
             }
-       
+
             var response = req.CreateResponse(HttpStatusCode.OK);
-            await response.WriteAsJsonAsync(result);   
-            return response;    
+            await response.WriteAsJsonAsync(result);
+            return response;
         }
     }
 }


### PR DESCRIPTION
Removed the claims check from the Function that creates the shortened URLs. This will allow the backend services to hit the endpoint. The Static Web App will then be locked down by IP (NJ and FL offices and the dev cluster vnet range).

Also fixed type being passed to CreateLogger as I believe they are typos. Also creating PR to https://github.com/FBoucher/TinyBlazorAdmin to fix those.