### PR TITLE
deploy to function app instead of static site

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,33 +1,43 @@
-name: Deploy web app to Azure Static Web Apps
-
-env:
-  APP_LOCATION: "src/client"
-  API_LOCATION: "src/api"
-  APP_ARTIFACT_LOCATION: "wwwroot"
+name: Deploy DotNet project to Azure Function App
 
 on:
   push:
     branches:
       - main
 
-permissions:
-  issues: write
-  contents: read
+env:
+  AZURE_FUNCTIONAPP_NAME: "Dev-STORIS-URL-Shortener-Frontend"
+  AZURE_FUNCTIONAPP_PACKAGE_PATH: "."
+  DOTNET_VERSION: "6.0.x"
 
 jobs:
-  build_and_deploy:
-    runs-on: ubuntu-latest
-    name: Build and Deploy
+  build-and-deploy:
+    runs-on: windows-latest
+    environment: dev
     steps:
-      - uses: actions/checkout@v3
+      - name: "Checkout GitHub Action"
+        uses: actions/checkout@v3
+
+      - name: "Login via Azure CLI"
+        uses: azure/login@v1
         with:
-          submodules: true
-      - name: Build And Deploy
-        uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9
+          creds: ${{ secrets.AZURE_RBAC_CREDENTIALS }}
+
+      - name: Setup DotNet ${{ env.DOTNET_VERSION }} Environment
+        uses: actions/setup-dotnet@v3
         with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          action: "upload"
-          app_location: ${{ env.APP_LOCATION }}
-          api_location: ${{ env.API_LOCATION }}
-          app_artifact_location: ${{ env.APP_ARTIFACT_LOCATION }}
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: "Resolve Project Dependencies Using Dotnet"
+        shell: pwsh
+        run: |
+          pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
+          dotnet build --configuration Release --output ./output
+          popd
+
+      - name: "Run Azure Functions Action"
+        uses: Azure/functions-action@v1
+        id: fa
+        with:
+          app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+          package: "${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}/output"


### PR DESCRIPTION
This PR changes the deploy workflow to deploy to an Azure Function App instead of an Azure Static Web App. This uses the same template as the AzUrlShortener repo's deploy workflow.