### PR TITLE
change auth level from anonymous to function

### DIFF
--- a/src/api/function/UrlShortener.cs
+++ b/src/api/function/UrlShortener.cs
@@ -48,7 +48,7 @@ namespace Cloud5mins.Function
 
         [Function("UrlShortener")]
         public async Task<HttpResponseData> Run(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)] HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequestData req,
             ExecutionContext context
         )
         {


### PR DESCRIPTION
This PR changes the authorization level for the UrlShortener function to `Function`. This requires that the Function Access key be passed in the request header to authorize the action.

I have added the Url Shortener Function Access Key as a secret to the `storis-dev` Azure Key Vault under the name `URL-SHORTENER-FUNCTION-ACCESS-KEY`.