### PR TITLE
change workflow names and change runner to ubuntu

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -1,4 +1,4 @@
-name: Deploy DotNet project to Azure Function App
+name: Deploy DotNet project to Azure Function App dev
 
 on:
   push:
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-and-deploy:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     environment: dev
     steps:
       - name: "Checkout GitHub Action"

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -1,4 +1,4 @@
-name: Deploy DotNet project to Azure Function App
+name: Deploy DotNet project to Azure Function App prod
 
 on:
   release:
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build-and-deploy:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     environment: prod
     steps:
       - name: "Checkout GitHub Action"


### PR DESCRIPTION
This PR renames the deploy workflows for better differentiation and converts the runners to Ubuntu. There is currently an open issue with the .Net SDK included in the Windows runner that is fixed in the Ubuntu runner, https://github.com/actions/runner-images/issues/7215. This is causing deployments to fail regardless of the SDK targeted, as it will use the latest SDK with this version.