### PR TITLE
Add KeepAlive function

### DIFF
--- a/src/api/function/KeepAlive.cs
+++ b/src/api/function/KeepAlive.cs
@@ -1,0 +1,73 @@
+using Cloud5mins.domain;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace UrlShortner.function
+{
+    public class KeepAlive
+    {
+        private const string WebsiteHostname = "WEBSITE_HOSTNAME";
+
+        private NLogWrapper _logger;
+
+        public KeepAlive(ILoggerFactory loggerFactory, AdminApiSettings settings)
+        {
+            _logger = new NLogWrapper(LoggerType.UrlPurger, settings);
+        }
+
+        [Function("KeepAlive")]
+        public async Task Run([TimerTrigger("0 */15 * * * *")] MyInfo myTimer)
+        {
+            var hostName = Environment.GetEnvironmentVariable(WebsiteHostname);
+            if (string.IsNullOrEmpty(hostName))
+            {
+                _logger.Log(NLog.LogLevel.Error, "Environment variable {WebsiteHostname} does not exist or has no value.", WebsiteHostname);
+                return;
+            }
+
+            var protocol = "https";
+#if DEBUG
+            protocol = "http";
+#endif
+            var urlShortenerEndpoint = $"{protocol}://{hostName}/api/urlshortener/";
+            var httpClient = new HttpClient();
+
+            try
+            {
+                var result = await httpClient.GetAsync(urlShortenerEndpoint);
+                if (result.IsSuccessStatusCode)
+                {
+                    _logger.Log(NLog.LogLevel.Info, "Keep alive for {urlShortenerEndpoint} was successfull", urlShortenerEndpoint);
+                }
+                else
+                {
+                    _logger.Log(NLog.LogLevel.Warn, "Keep alive for {urlShortenerEndpoint} failed. HTTP Status Code = {statusCode}",
+                        urlShortenerEndpoint, result.StatusCode.ToString());
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Log(NLog.LogLevel.Error, "An unexpected error was encountered: {message}", ex.Message);
+            }
+        }
+    }
+
+    public class MyInfo
+    {
+        public MyScheduleStatus ScheduleStatus { get; set; }
+
+        public bool IsPastDue { get; set; }
+    }
+
+    public class MyScheduleStatus
+    {
+        public DateTime Last { get; set; }
+
+        public DateTime Next { get; set; }
+
+        public DateTime LastUpdated { get; set; }
+    }
+}

--- a/src/api/function/UrlPurger.cs
+++ b/src/api/function/UrlPurger.cs
@@ -20,7 +20,7 @@ namespace UrlPurger.function
         }
 
         [Function("UrlPurger")]
-        public async Task Run([TimerTrigger("0 0 6 * * *", RunOnStartup = true)] MyInfo myTimer)
+        public async Task Run([TimerTrigger("0 0 6 * * *")] MyInfo myTimer)
         {
             logger.Log(NLog.LogLevel.Info, "C# Timer trigger function executed at {trigger.current}", DateTime.Now.ToString());
             logger.Log(NLog.LogLevel.Info, "Next timer scheduled for {trigger.next}", myTimer.ScheduleStatus.Next.ToString());

--- a/src/api/function/UrlShortener.cs
+++ b/src/api/function/UrlShortener.cs
@@ -64,6 +64,12 @@ namespace Cloud5mins.Function
                     return req.CreateResponse(HttpStatusCode.NotFound);
                 }
 
+                if (req.Method == "GET")
+                {
+                    // being called from KeepAlive function
+                    return req.CreateResponse(HttpStatusCode.OK);
+                }
+
                 using (var reader = new StreamReader(req.Body))
                 {
                     var strBody = reader.ReadToEnd();


### PR DESCRIPTION
Azure Functions running on the Consumption Plan are subject to cold starts when the function has not been called in the last ~20 minutes. Since calls to the UrlShortener function from our backend services occur during a user initiated request the user could be left hanging for ~10 seconds in the event the function is performing a cold start. The Consumption Plan is really cheap so in order to stay on it we're going to try adding another KeepAlive function that will ping the UrlShortener function every 15 minutes.