### PR TITLE
CXM-5555: UrlPurger function to log variable values and disable trigger on startup

### DIFF
--- a/src/api/function/UrlPurger.cs
+++ b/src/api/function/UrlPurger.cs
@@ -22,15 +22,16 @@ namespace UrlPurger.function
         [Function("UrlPurger")]
         public async Task Run([TimerTrigger("0 0 6 * * *", RunOnStartup = false)] MyInfo myTimer)
         {
-            logger.Log(NLog.LogLevel.Info, "C# Timer trigger function executed at {trigger.current}", DateTime.Now.ToString());
-            logger.Log(NLog.LogLevel.Info, "Next timer scheduled for {trigger.next}", myTimer.ScheduleStatus.Next.ToString());
+            logger.Log(NLog.LogLevel.Info, "C# Timer trigger function executed at {0}", DateTime.Now.ToString());
+            logger.Log(NLog.LogLevel.Info, "Next timer scheduled for {0}", myTimer.ScheduleStatus.Next.ToString());
 
             var storageTableHelper = new StorageTableHelper(_adminApiSettings.UlsDataStorage);
             var urlsToPurge = await storageTableHelper.GetShortUrlEntitiesToPurge(7);
             foreach (var urlToPurge in urlsToPurge)
             {
 
-                logger.Log(NLog.LogLevel.Info, "Deleting ShortUrl: {0} | Title: {1} | CreatedAt: {2}", urlToPurge.RowKey, urlToPurge.Title, urlToPurge.Timestamp.ToString());
+                logger.Log(NLog.LogLevel.Info, "Deleting ShortUrl: {0} | Title: {1} | CreatedAt: {2}",
+                    urlToPurge.RowKey, urlToPurge.Title, urlToPurge.Timestamp.ToString());
 
                 await storageTableHelper.DeleteShortUrlEntity(urlToPurge);
             }

--- a/src/api/function/UrlPurger.cs
+++ b/src/api/function/UrlPurger.cs
@@ -20,7 +20,7 @@ namespace UrlPurger.function
         }
 
         [Function("UrlPurger")]
-        public async Task Run([TimerTrigger("0 0 6 * * *", RunOnStartup = true)] MyInfo myTimer)
+        public async Task Run([TimerTrigger("0 0 6 * * *", RunOnStartup = false)] MyInfo myTimer)
         {
             logger.Log(NLog.LogLevel.Info, "C# Timer trigger function executed at {trigger.current}", DateTime.Now.ToString());
             logger.Log(NLog.LogLevel.Info, "Next timer scheduled for {trigger.next}", myTimer.ScheduleStatus.Next.ToString());
@@ -30,7 +30,7 @@ namespace UrlPurger.function
             foreach (var urlToPurge in urlsToPurge)
             {
 
-                logger.Log(NLog.LogLevel.Info, "Deleting ShortUrl: {urlToPurge.ShortUrl} | Title: {urlToPurge.Title} | CreatedAt: {urlToPurge.Timestamp}", urlToPurge.RowKey, urlToPurge.Title, urlToPurge.Timestamp.ToString());
+                logger.Log(NLog.LogLevel.Info, "Deleting ShortUrl: {0} | Title: {1} | CreatedAt: {2}", urlToPurge.RowKey, urlToPurge.Title, urlToPurge.Timestamp.ToString());
 
                 await storageTableHelper.DeleteShortUrlEntity(urlToPurge);
             }

--- a/src/api/function/UrlShortener.cs
+++ b/src/api/function/UrlShortener.cs
@@ -86,7 +86,7 @@ namespace Cloud5mins.Function
                 // Validates if input.url is a valid aboslute url, aka is a complete refrence to the resource, ex: http(s)://google.com
                 if (!Uri.IsWellFormedUriString(input.Url, UriKind.Absolute))
                 {
-                    logger.Log(NLog.LogLevel.Warn, "{url.longUrl} is not a valid absolute Url. The Url parameter must start with 'http://' or 'https://'.", input.Url);
+                    logger.Log(NLog.LogLevel.Warn, "{0} is not a valid absolute Url. The Url parameter must start with 'http://' or 'https://'.", input.Url);
                     var badResponse = req.CreateResponse(HttpStatusCode.BadRequest);
                     await badResponse.WriteAsJsonAsync(new { message = $"{input.Url} is not a valid absolute Url. The Url parameter must start with 'http://' or 'https://'." });
                     return badResponse;
@@ -106,7 +106,7 @@ namespace Cloud5mins.Function
                     newRow = new ShortUrlEntity(longUrl, vanity, title, input.Schedules);
                     if (await stgHelper.IfShortUrlEntityExist(newRow))
                     {
-                        logger.Log(NLog.LogLevel.Warn, "The Short URL {url.shortUrl} already exists.", vanity);
+                        logger.Log(NLog.LogLevel.Warn, "The Short URL {0} already exists.", vanity);
                         var badResponse = req.CreateResponse(HttpStatusCode.Conflict);
                         await badResponse.WriteAsJsonAsync(new { message = $"The Short URL {vanity} already exists." });
                         return badResponse;
@@ -122,11 +122,11 @@ namespace Cloud5mins.Function
                 var host = string.IsNullOrEmpty(_adminApiSettings.customDomain) ? req.Url.Host : _adminApiSettings.customDomain.ToString();
                 result = new ShortResponse(host, newRow.Url, newRow.RowKey, newRow.Title);
 
-                logger.Log(NLog.LogLevel.Info, "Short Url {url.shortUrl} for url {url.longUrl} created", newRow.RowKey, longUrl);
+                logger.Log(NLog.LogLevel.Info, "Short Url {0} for url {1} created", newRow.RowKey, longUrl);
             }
             catch (Exception ex)
             {
-                logger.Log(NLog.LogLevel.Error, "An unexpected error was encountered: {message}", ex.Message);
+                logger.Log(NLog.LogLevel.Error, "An unexpected error was encountered: {0}", ex.Message);
                 var badResponse = req.CreateResponse(HttpStatusCode.BadRequest);
                 await badResponse.WriteAsJsonAsync(new { message = ex.Message });
                 return badResponse;

--- a/src/lib/NLogWrapper.cs
+++ b/src/lib/NLogWrapper.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Web;
-using Cloud5mins.domain;
+﻿using Cloud5mins.domain;
 using NLog;
 
 public enum LoggerType
@@ -23,7 +21,7 @@ public class NLogWrapper
         initializeLogger(loggerType, settings);
     }
 
-    public void Log(LogLevel logLevel, String message, string arg1 = null, string arg2 = null, string arg3 = null)
+    public void Log(LogLevel logLevel, String message, params object[] args)
     {
         NLog.LogManager.Configuration = new NLog.Config.XmlLoggingConfiguration("NLog.config");
         var configuration = LogManager.Configuration;
@@ -35,7 +33,7 @@ public class NLogWrapper
 
         getCallerName();
 
-        logger.Log(logLevel, message, arg1, arg2);
+        logger.Log(logLevel, message, args);
     }
 
     private void initializeLogger(LoggerType loggerType, AdminApiSettings settings)


### PR DESCRIPTION
Fixed issue where variable values were not being incorporated into logs.
Set UrlPurger function's `RunOnStartup` param to `false`.
Updated the `NLogWrapper` classes log method to accept an unknown number of replacement values.